### PR TITLE
Add environment-based test validation

### DIFF
--- a/src/test/java/com/dfsantos/hgtonline/HgtonlineApplicationTests.java
+++ b/src/test/java/com/dfsantos/hgtonline/HgtonlineApplicationTests.java
@@ -1,11 +1,19 @@
 package com.dfsantos.hgtonline;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class HgtonlineApplicationTests {
 
+    @Autowired
+    private Environment environment;
+
     @Test
-    void contextLoads() {}
+    void contextLoads() {
+        assertEquals("hgtonline", environment.getProperty("spring.application.name"));
+    }
 }


### PR DESCRIPTION
## Summary
- inject `Environment` into tests
- check that `spring.application.name` is `hgtonline`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6845dca789488333bd2da61ed95a5904