### PR TITLE
Fix typo in test architecture docs

### DIFF
--- a/docs/arquitetura/testes/index.md
+++ b/docs/arquitetura/testes/index.md
@@ -11,7 +11,7 @@ duas variantes de estrutura de teste unitário:
 Deve seguir o modelo básico de BDD, que é:
 
 - Given / When / Then;
-- Esses blocos podem ser subdividodos em blocos menores com 'And';
+- Esses blocos podem ser subdivididos em blocos menores com 'And';
 
 ### Given
 


### PR DESCRIPTION
## Summary
- fix typo in BDD test docs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6845ddc9a9c08333907d4b33b3999232